### PR TITLE
Fix to missing 'logo' images

### DIFF
--- a/packages/racer/src/profiling/index.ts
+++ b/packages/racer/src/profiling/index.ts
@@ -111,7 +111,7 @@ const launchLighthouse = async (
           networkQuietThresholdMs: 5000,
           cpuQuietThresholdMs: 5000,
           // todo: bring these blocked URL patterns in via some config
-          blockedUrlPatterns: ['*log*'],
+          // blockedUrlPatterns: [],
           gatherers: [
             'trace',
             'trace-compat',
@@ -121,7 +121,7 @@ const launchLighthouse = async (
             //   'viewport-dimensions',
             //   'console-messages',
             //   'anchor-elements',
-            //   'image-elements',
+            'image-elements',
             //   'link-elements',
             //   'meta-elements',
             //   'script-elements',


### PR DESCRIPTION
## Description

A small tweak to our racer, which removes the hard-coded 'blockedUrlPatterns' setting. This was an artifact of earlier testing, to filter out various 'log' calls in our environment. 

In the future, we should pursue setting these 'filtered urls' as a configuration setting