### PR TITLE
Replace dnslookup with dig

### DIFF
--- a/packages/racer/Dockerfile
+++ b/packages/racer/Dockerfile
@@ -9,19 +9,14 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.14/community" >> /etc/apk/rep
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.14/main/" >> /etc/apk/repositories
 
 RUN apk upgrade && \
-    apk add --no-cache dbus chromium chromium-chromedriver bash curl dnsmasq
-#apk add --no-cache dbus chromium chromium-chromedriver
-#dbus-daemon --system
+    apk add --no-cache dbus chromium chromium-chromedriver bash curl dnsmasq bind-tools
 
 COPY . /rp/
 WORKDIR /rp/
 
-# RUN dbus-daemon --system
 RUN npm install
 RUN npm install -g lighthouse
 RUN chmod +x update-dns.sh 
-# && ./update-dns.sh
-# RUN dnsmasq
 
 EXPOSE ${RACER_PORT:-3000}/tcp
 

--- a/packages/racer/update-dns.sh
+++ b/packages/racer/update-dns.sh
@@ -5,7 +5,8 @@
 # * updates the dnsmasq config with that information
 # * updates the /etc/resolv.conf with localhost, thus making it such that this system is its own dns server
 echo "Updating ip address in order to treat local dnsmasq as our dns resolver and route all calls to raceproxy"
-ip=$(nslookup raceproxy | awk '/Address:/ {split($2,d,":");print d[1]}' | tail -n 1)
+# the next line after the 'Answer Section' contains the first match of the domain and its ip
+ip=$(dig raceproxy | awk '/ANSWER SECTION/ {getline;print $5;}')
 
 echo "The ip in question is $ip"
 
@@ -16,9 +17,7 @@ listen-address=::1,127.0.0.1
 address=/#/$ip" >> /etc/dnsmasq.conf
 
 echo "dnsmasq config updated. Replacing /etc/resolv.conf"
-
-# rm /etc/resolv.conf
-sed '1,2d' /etc/resolv.conf
-
+# resolv.conf is actively used by a special mount created by the Docker environment. We cannot cp or rm the file, but we can
+# replace all the text inside
 echo "nameserver 127.0.0.1
-options ndots:0" >> /etc/resolv.conf 
+options ndots:0" > /etc/resolv.conf 


### PR DESCRIPTION

## Description

Replaces the usage of `nslookup` with `dig` within the racer. Nslookup functionality is spotty and is unable to always resolve the location of `raceproxy` during startup. Dig is a newer tool which in testing is far more reliable.

