### PR TITLE
Additional flags + polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,17 +169,19 @@ Racepoint accepts the following commands and flags:
 
 - `profile` - perform a number of Lighthouse runs against a single URL
 
-| <span style="display: inline-block; width:200px">Flag</span> | Description                                                |
-| ------------------------------------------------------------ | ---------------------------------------------------------- |
-| --chrome-flags                                               | Additional Chrome flags for the emulated browser.          |
-| -d, --device-type                                            | Device type to emulate (default: "mobile")                 |
-| --include-individual                                         | Will display the results of individual runs to the console |
-| -n, --number-runs                                            | Number of Lighthouse runs per URL (default: 1)             |
-| --output-target                                              | Location to save results (defaults to current directory)   |
-| --output-format                                              | Save results as CSV, HTML, or both                         |
-| --racer-port                                                 | Port to start the racer container (default: "3000")        |
-| --repository-id                                              | Name of the repository file (default: "lighthouse-runs")   |
-| -h, --help                                                   | Display help for command                                   |
+| <span style="display: inline-block; width:200px">Flag</span> | Description                                                               |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| --chrome-flags                                               | Additional comma-delimeted list of Chrome flags for the emulated browser. |
+| -d, --device-type                                            | Device type to emulate (default: "mobile")                                |
+| --disable-storage-reset                                      | If set, will preserve the browser cache between runs.                     |
+| --extra-headers                                              | A JSON-encoded string of additional headers to use on during profiling.   |
+| --include-individual                                         | Will display the results of individual runs to the console                |
+| -n, --number-runs                                            | Number of Lighthouse runs per URL (default: 1)                            |
+| --output-target                                              | Location to save results (defaults to current directory)                  |
+| --output-format                                              | Save results as CSV, HTML, or both                                        |
+| --racer-port                                                 | Port to start the racer container (default: "3000")                       |
+| --repository-id                                              | Name of the repository file (default: "lighthouse-runs")                  |
+| -h, --help                                                   | Display help for command                                                  |
 
 ### Debug
 

--- a/packages/race-cli/src/helpers.ts
+++ b/packages/race-cli/src/helpers.ts
@@ -29,6 +29,21 @@ export const parseUrlArg = (value: string) => {
   }
 };
 
+/**
+ * Parses input from the user regarding chrome strings
+ *
+ * @param value the comma-delimted string provided by the user
+ */
+export const splitChromeArgs = (value: string): string[] => {
+  const segments = value.split(',');
+  segments.forEach((flag) => {
+    if (!flag.startsWith('--')) {
+      throw new commander.InvalidArgumentError('flags must start with "--"');
+    }
+  });
+  return segments;
+};
+
 /*
   Helper function to format ISO date and full URL for report files
   Matches the output from Lighthouse

--- a/packages/race-cli/src/index.ts
+++ b/packages/race-cli/src/index.ts
@@ -6,6 +6,7 @@ import {
   raceLogo,
   parseIntArg,
   parseUrlArg,
+  splitChromeArgs,
 } from './helpers';
 import {ProfileScenario, PROFILE_COMMAND} from './scenarios/profile';
 
@@ -34,8 +35,10 @@ program
   .option(
     '--chrome-flags <string>',
     descriptionHelper(
-      'Chrome flags for the emulated browser. Will be merged with necessary defaults.'
-    )
+      'Chrome flags for the emulated browser. Will be merged with necessary defaults. Should be a comma-delimited list of arguments.'
+    ),
+    splitChromeArgs,
+    []
   )
   .option(
     '-d, --device-type <device>',
@@ -48,6 +51,20 @@ program
       'Will display the results of individual runs to the console'
     ),
     false
+  )
+  .option(
+    '--disable-storage-reset',
+    descriptionHelper(
+      'If set, will preserve the browser cache between runs. By default this is false in order to treat the experience as a brand new user each iteration.'
+    ),
+    false
+  )
+  .option(
+    '--extra-headers <JSON string>',
+    descriptionHelper(
+      'A JSON strong of Headers that you wish to be included on each request. e.g. "{\\"Cookie\\":\\"monster=blue\\", \\"x-men\\":\\"wolverine\\"}"'
+    ),
+    JSON.parse
   )
   .option(
     '-n, --number-runs <number>',

--- a/packages/race-cli/src/types.ts
+++ b/packages/race-cli/src/types.ts
@@ -61,6 +61,9 @@ export class ProfileContext implements ScenarioContext {
   outputTarget: string;
   repositoryId: string;
   includeIndividual: boolean;
+  chromeFlags?: string[];
+  extraHeaders?: Record<string, string>;
+  disableStorageReset?: boolean;
 
   constructor(userArgs: any) {
     this.targetUrl = userArgs?.targetUrl || '';
@@ -70,6 +73,9 @@ export class ProfileContext implements ScenarioContext {
     this.outputTarget = userArgs?.outputTarget;
     this.repositoryId = userArgs?.repositoryId;
     this.includeIndividual = userArgs.includeIndividual;
+    this.chromeFlags = userArgs?.chromeFlags;
+    this.extraHeaders = userArgs?.extraHeaders;
+    this.disableStorageReset = userArgs?.disableStorageReset;
   }
 }
 

--- a/packages/race-cli/tests/helpers.spec.ts
+++ b/packages/race-cli/tests/helpers.spec.ts
@@ -1,0 +1,21 @@
+import {expect} from 'chai';
+import {splitChromeArgs} from '../src/helpers';
+
+describe('Chrome flags helper', () => {
+  it('should handle a single flag', () => {
+    const flags = splitChromeArgs('--test-me');
+    expect(flags).to.eql(['--test-me']);
+  });
+
+  it('should split multiple', () => {
+    const flags = splitChromeArgs('--test-me,--disable-cache,--foo-bar');
+    expect(flags).to.eql(['--test-me', '--disable-cache', '--foo-bar']);
+  });
+
+  it('should fail if an invalid flag is passed', () => {
+    const failure = () => {
+      splitChromeArgs('--test-me,--foo-bar,BLARG,--valid-flag');
+    };
+    expect(failure).to.throw('flags must start with "--"');
+  });
+});

--- a/packages/racer/src/controllers/profile.ts
+++ b/packages/racer/src/controllers/profile.ts
@@ -39,7 +39,7 @@ export const ProfileEndpoint: RegisteredEndpoint<object> = {
   method: 'POST',
   handler: async (req, res, parsedUrl) => {
     return maybeRunLighthouse(
-      // we parse the instruction from the cli as a context object pulled from the 'lower level'; we're reachign across a boundary here
+      // we parse the instruction from the cli as a context object pulled from the 'lower level'; we're reaching across a boundary here
       // it may be wise to create a specific API object and add some mapping code later to separate what we
       // expect callers to send to us versus what the internal operations work on
       (await extractBodyFromRequest(req)) as RaceProfileCommand

--- a/packages/racer/src/controllers/profile.ts
+++ b/packages/racer/src/controllers/profile.ts
@@ -9,48 +9,40 @@ import {
 } from '../server/utils';
 import {UsageLock} from '../usageLock';
 import {submitLighthouseRun} from '../profiling/index';
+import {RaceProfileCommand} from '../profiling/config';
 
-/**
- * Defines the configuration and properties we expect for a given Lighthouse run
- */
-interface RaceContext {
-  targetUrl: string;
-  deviceType: 'desktop' | 'mobile';
-  chromeFlags: string[];
-}
-
-const isValid = (context: RaceContext): boolean => {
+const isValid = (context: RaceProfileCommand): boolean => {
   //trivial validation for now
   return context != undefined && context.targetUrl != undefined;
 };
 
 const maybeRunLighthouse = async (
-  context: RaceContext
+  context: RaceProfileCommand
 ): Promise<EndpointResponse<object>> => {
-  // try to get a lock; if LH is currently in use, send back a 503!
-  if (await UsageLock.getInstance().tryAcquire()) {
-    return new EndpointResponse({
-      // submit lighthouse run; it will return nearly immediately but then run an additional async process
-      jobId: await submitLighthouseRun(context),
-    });
-  } else {
-    return new EndpointResponse({
-      error: 'Racer is currently in use',
-    }).withStatusCode(503);
+  const response = new EndpointResponse<object>({});
+  // first check validity. Currently this is a trivial operation
+  if (!isValid(context)) {
+    response.withBody({error: 'Payload is not valid'}).withStatusCode(400);
   }
+  // try to get a lock; if LH is currently in use, send back a 503!
+  else if (await UsageLock.getInstance().tryAcquire()) {
+    const jobId = await submitLighthouseRun(context);
+    response.withBody({jobId}).withStatusCode(200);
+  } else {
+    response.withBody({error: 'Racer is currently in use'}).withStatusCode(503);
+  }
+  return response;
 };
 
 export const ProfileEndpoint: RegisteredEndpoint<object> = {
   path: '/race',
   method: 'POST',
   handler: async (req, res, parsedUrl) => {
-    const payload = (await extractBodyFromRequest(req)) as RaceContext;
-    if (isValid(payload)) {
-      return maybeRunLighthouse(payload);
-    } else {
-      return new EndpointResponse({
-        error: 'Payload is not valid',
-      }).withStatusCode(400);
-    }
+    return maybeRunLighthouse(
+      // we parse the instruction from the cli as a context object pulled from the 'lower level'; we're reachign across a boundary here
+      // it may be wise to create a specific API object and add some mapping code later to separate what we
+      // expect callers to send to us versus what the internal operations work on
+      (await extractBodyFromRequest(req)) as RaceProfileCommand
+    );
   },
 };

--- a/packages/racer/src/profiling/config.ts
+++ b/packages/racer/src/profiling/config.ts
@@ -1,0 +1,94 @@
+import {Options} from 'chrome-launcher';
+import {OutputMode} from 'lighthouse/types/lhr/settings';
+import {Flags} from 'lighthouse/types/externs';
+
+/**
+ * Defines the configuration and properties we expect for a given Lighthouse run
+ */
+export interface RaceProfileCommand {
+  targetUrl: string;
+  deviceType?: 'desktop' | 'mobile';
+  chromeFlags?: string[];
+  extraHeaders?: Record<string, string>;
+  disableStorageReset?: boolean;
+}
+
+/**
+ * encapsulates all of the variables and defaults that are needed as part of the Lighthouse and Chrome runs. Utilizes the RaceProfileCommand
+ * but ensures various defaults are set
+ */
+export class RaceContext {
+  jobId: number;
+  targetUrl: string;
+  deviceType = 'desktop';
+  chromeFlags: string[] = [];
+  disableStorageReset = false;
+  extraHeaders: Record<string, string> = {};
+
+  constructor(requestedJobId: number, command: RaceProfileCommand) {
+    this.jobId = requestedJobId;
+    this.targetUrl = command.targetUrl;
+    this.deviceType = command.deviceType || this.deviceType;
+    this.disableStorageReset =
+      command.disableStorageReset || this.disableStorageReset;
+    // equivalent of java '.addAll()'
+    this.chromeFlags.push(...(command.chromeFlags || []));
+
+    this.extraHeaders = command.extraHeaders || this.extraHeaders;
+  }
+}
+
+export const constructChromeOptions = (context: RaceContext): Options => {
+  return {
+    logLevel: 'verbose',
+    chromeFlags: [
+      '--headless',
+      '--disable-gpu',
+      '--no-sandbox',
+      '--ignore-certificate-errors',
+      '--disable-dev-shm-usage',
+      '--disable-setuid-sandbox',
+      ...context.chromeFlags,
+    ],
+  };
+};
+
+export const constructLighthouseFlags = (
+  chromePort: number,
+  context: RaceContext
+): Flags => {
+  const desktopSettings = {
+    formFactor: 'desktop' as const,
+    screenEmulation: {
+      mobile: false,
+      width: 1440,
+      height: 900,
+      deviceScaleFactor: 1,
+    },
+  };
+  //--screenEmulation.mobile --screenEmulation.width=360 --screenEmulation.height=640 --screenEmulation.deviceScaleFactor=2
+  // are these acceptable mobile defaults? taken from the suggested lighthouse flags (the line above)
+  const mobileSettings = {
+    formFactor: 'mobile' as const,
+    screenEmulation: {
+      mobile: true,
+      width: 360,
+      height: 640,
+      deviceScaleFactor: 2,
+    },
+  };
+
+  const lhFlags: Flags = {
+    output: 'html' as OutputMode,
+    port: chromePort,
+    logLevel: 'info',
+    extraHeaders: context.extraHeaders,
+    // unfortunately, setting a max wait causes the lighthouse run to break. can investigate in the future
+    // maxWaitForLoad: 12500
+    ...(context.deviceType === 'desktop'
+      ? {...desktopSettings}
+      : {...mobileSettings}),
+  };
+
+  return lhFlags;
+};

--- a/packages/racer/src/profiling/config.ts
+++ b/packages/racer/src/profiling/config.ts
@@ -80,6 +80,7 @@ export const constructLighthouseFlags = (
 
   const lhFlags: Flags = {
     output: 'html' as OutputMode,
+    disableStorageReset: context.disableStorageReset,
     port: chromePort,
     logLevel: 'info',
     extraHeaders: context.extraHeaders,

--- a/packages/racer/src/profiling/config.ts
+++ b/packages/racer/src/profiling/config.ts
@@ -40,7 +40,7 @@ export class RaceContext {
 
 export const constructChromeOptions = (context: RaceContext): Options => {
   return {
-    logLevel: 'verbose',
+    logLevel: 'info',
     chromeFlags: [
       '--headless',
       '--disable-gpu',

--- a/packages/racer/src/profiling/index.ts
+++ b/packages/racer/src/profiling/index.ts
@@ -27,45 +27,12 @@ export const submitLighthouseRun = async (
 };
 
 const profileWithLighthouse = async (context: RaceContext) => {
-  // const chromeOptions: Options = {
-  //   logLevel: 'verbose',
-  //   chromeFlags: [
-  //     '--headless',
-  //     '--disable-gpu',
-  //     '--no-sandbox',
-  //     '--ignore-certificate-errors',
-  //     '--disable-dev-shm-usage',
-  //     '--disable-setuid-sandbox',
-  //     ...chromeFlags,
-  //   ],
-  // };
-  const chromeOptions = constructChromeOptions(context);
-
-  // const desktopSettings = {
-  //   formFactor: 'desktop',
-  //   screenEmulation: {
-  //     mobile: false,
-  //     width: 1440,
-  //     height: 900,
-  //     deviceScaleFactor: 1,
-  //   },
-  // };
-
   // chrome takes a moment or two to spinup
   console.log('Preparing Chrome');
-  const chrome = await launch(chromeOptions);
+  //todo: debug log the context?
+  const chrome = await launch(constructChromeOptions(context));
+  // setup the Lighthouse flags. This differs from the third argument to lighthouse, which is test or 'pass' information.
   const lighthouseFlags = constructLighthouseFlags(chrome.port, context);
-  // setup the Lighthouse flags. This differs from the third argument, which is test or 'pass' information
-  // const lhFlags = {
-  //   //   chromeOptions.chromeFlags,
-  //   output: 'html',
-  //   port: chrome.port,
-  //   logLevel: 'info',
-  //   // unfortunately, setting a max wait causes the lighthouse run to break. can investigate in the future
-  //   // maxWaitForLoad: 12500
-  //   ...(deviceType === 'desktop' && {...desktopSettings}),
-  // };
-
   // and go
   console.log('Starting Lighthouse');
   const results = await launchLighthouse(context.targetUrl, lighthouseFlags);

--- a/packages/racer/tests/context.spec.ts
+++ b/packages/racer/tests/context.spec.ts
@@ -42,7 +42,7 @@ describe('Chrome Options construction', () => {
     });
 
     const options = constructChromeOptions(bare);
-    expect(options.logLevel).to.be.equal('verbose');
+    expect(options.logLevel).to.be.equal('info');
     expect(options.chromeFlags).to.not.be.empty;
     expect(options.chromeFlags!!.length).to.be.equal(6);
   });
@@ -54,7 +54,7 @@ describe('Chrome Options construction', () => {
         chromeFlags: ['--crash-on-failure', '--disable-notifications'],
       })
     );
-    expect(options.logLevel).to.be.equal('verbose');
+    expect(options.logLevel).to.be.equal('info');
     expect(options.chromeFlags!!.length).to.be.equal(8);
     expect(options.chromeFlags!!).to.contain('--crash-on-failure');
     expect(options.chromeFlags!!).to.contain('--disable-notifications');

--- a/packages/racer/tests/context.spec.ts
+++ b/packages/racer/tests/context.spec.ts
@@ -1,0 +1,116 @@
+import chai, {expect} from 'chai';
+import exp from 'constants';
+import {
+  RaceContext,
+  RaceProfileCommand,
+  constructChromeOptions,
+  constructLighthouseFlags,
+} from '../src/profiling/config';
+
+describe('Race Context parsing', () => {
+  it('should have appropriate defaults', () => {
+    const defaultContext = new RaceContext(1, {
+      targetUrl: 'https://www.google.com',
+    });
+    expect(defaultContext.targetUrl).to.be.equal('https://www.google.com');
+    expect(defaultContext.deviceType).to.be.equal('desktop');
+    expect(defaultContext.chromeFlags).to.be.empty;
+    expect(defaultContext.jobId).to.be.equal(1);
+    expect(defaultContext.disableStorageReset).to.be.false;
+  });
+
+  it('should allow for overrides', () => {
+    const overriddenContext = new RaceContext(42, {
+      targetUrl: 'https://www.example.com',
+      chromeFlags: ['--crash-on-failure', '--disable-notifications'],
+      deviceType: 'mobile',
+      disableStorageReset: true,
+    });
+
+    expect(overriddenContext.targetUrl).to.be.equal('https://www.example.com');
+    expect(overriddenContext.deviceType).to.be.equal('mobile');
+    expect(overriddenContext.chromeFlags.length).to.be.equal(2);
+    expect(overriddenContext.jobId).to.be.equal(42);
+    expect(overriddenContext.disableStorageReset).to.be.true;
+  });
+});
+
+describe('Chrome Options construction', () => {
+  it('should ignore empty flags', () => {
+    const bare = new RaceContext(5, {
+      targetUrl: 'https://www.example.com',
+    });
+
+    const options = constructChromeOptions(bare);
+    expect(options.logLevel).to.be.equal('verbose');
+    expect(options.chromeFlags).to.not.be.empty;
+    expect(options.chromeFlags!!.length).to.be.equal(6);
+  });
+
+  it('should include additional flags', () => {
+    const options = constructChromeOptions(
+      new RaceContext(10, {
+        targetUrl: 'https://www.example.com',
+        chromeFlags: ['--crash-on-failure', '--disable-notifications'],
+      })
+    );
+    expect(options.logLevel).to.be.equal('verbose');
+    expect(options.chromeFlags!!.length).to.be.equal(8);
+    expect(options.chromeFlags!!).to.contain('--crash-on-failure');
+    expect(options.chromeFlags!!).to.contain('--disable-notifications');
+  });
+});
+
+describe('Lighthouse Flags construction', () => {
+  it('should construct a desktop settings block for desktop deviceType', () => {
+    const lhFlags = constructLighthouseFlags(
+      3001,
+      new RaceContext(10, {
+        targetUrl: 'https://www.example.com',
+      })
+    );
+    expect(lhFlags.output).to.be.equal('html');
+    expect(lhFlags.port).to.be.equal(3001);
+    expect(lhFlags.logLevel).to.be.equal('info');
+    expect(lhFlags.formFactor).to.be.equal('desktop');
+    expect(lhFlags.screenEmulation).to.eql({
+      mobile: false,
+      width: 1440,
+      height: 900,
+      deviceScaleFactor: 1,
+    });
+  });
+  it('should respect mobile deviceType', () => {
+    const lhFlags = constructLighthouseFlags(
+      3001,
+      new RaceContext(10, {
+        targetUrl: 'https://www.example.com',
+        deviceType: 'mobile',
+      })
+    );
+    expect(lhFlags.output).to.be.equal('html');
+    expect(lhFlags.port).to.be.equal(3001);
+    expect(lhFlags.logLevel).to.be.equal('info');
+    expect(lhFlags.formFactor).to.be.equal('mobile');
+    expect(lhFlags.screenEmulation).to.eql({
+      mobile: true,
+      width: 360,
+      height: 640,
+      deviceScaleFactor: 2,
+    });
+  });
+
+  it('should allow for extra headers', () => {
+    const lhFlags = constructLighthouseFlags(
+      3001,
+      new RaceContext(10, {
+        targetUrl: 'https://www.example.com',
+        extraHeaders: {'Content-Type': 'application/json', 'x-men': 'banshee'},
+      })
+    );
+    expect(lhFlags.extraHeaders).to.eql({
+      'Content-Type': 'application/json',
+      'x-men': 'banshee',
+    });
+  });
+});


### PR DESCRIPTION
-extracts the chrome and lighthouse flag logic from the core profile step into a testable set of functions
-adds tests
-adds support for additional flags - extra headers and the ability to preserve the browser cache on a run
-creates a separate payload api from the core RaceContext

## Description

This PR adds two new flags:

* additional headers -> allow callers to supply headers that Lighthouse will use during its requests (e.g. cookies, user JWTs)
* disableStorageReset -> if set, will allow users to NOT have lighthouse clear its cache during a run. 

Also polishes the code that governs the creation of Chrome Options and Lighthouse flags, extracting them and adding tests
