### PR TITLE
Create a Proxy Metrics store + retrieval endpoint

### DIFF
--- a/packages/proxy/src/cache-helpers.ts
+++ b/packages/proxy/src/cache-helpers.ts
@@ -3,6 +3,7 @@ import {IncomingMessage} from 'http';
 import {ProxyCache} from './proxy-cache';
 import {StatusCodes} from 'http-status-codes';
 import hash from 'object-hash';
+import {UrlWithParsedQuery} from 'url';
 
 export const CACHE_KEY_HEADER = 'll-cache-key';
 
@@ -66,6 +67,29 @@ export const trimKey = (key: string = '') =>
   key.length > 100
     ? key.slice(0, 50).concat('...', key.slice(key.length - 50, key.length))
     : key;
+
+/**
+ * Extracts an integer from a query param, or undefined
+ *
+ *
+ * @param url
+ * @param paramName
+ * @returns
+ */
+export const parseIntQueryParam = (
+  url: UrlWithParsedQuery,
+  paramName: string
+): number | undefined => {
+  if (url.query[paramName] === undefined) {
+    return undefined;
+  }
+
+  const parsed = parseInt(url.query[paramName]?.toString()!!);
+  if (isNaN(parsed)) {
+    return undefined;
+  }
+  return parsed;
+};
 
 /**
  * Takes a request and writes it to cache if not present

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -1,5 +1,6 @@
 import {ProxyCache} from './proxy-cache';
 import {buildHttpReverseProxy, buildHttp2ReverseProxy} from './reverse-proxy';
+import {getProxyMetrics} from './proxy-metrics';
 
 const HTTP_DEFAULT_PORT = 80;
 const HTTPS_DEFAULT_PORT = 443;
@@ -7,6 +8,10 @@ const HTTPS_DEFAULT_PORT = 443;
 const runProxy = async () => {
   // Inject for testability
   const cache = new ProxyCache();
+  // in order to appropriately listen for events ocurring in both of these servers, let's create
+  // a ProxyObservable, which acts as a pipeline for events originating in both locations
+  // then, a ProxyMetricsObserver which is consuming both of these.
+  getProxyMetrics();
 
   const HttpProxyServer = await buildHttpReverseProxy(cache);
   HttpProxyServer.listen(HTTP_DEFAULT_PORT);

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -8,7 +8,7 @@ const HTTPS_DEFAULT_PORT = 443;
 const runProxy = async () => {
   // Inject for testability
   const cache = new ProxyCache();
-  // in order to appropriately listen for events ocurring in both of these servers, let's create
+  // in order to appropriately listen for events occurring in both of these servers, let's create
   // a ProxyObservable, which acts as a pipeline for events originating in both locations
   // then, a ProxyMetricsObserver which is consuming both of these.
   getProxyMetrics();

--- a/packages/proxy/src/proxy-cache.ts
+++ b/packages/proxy/src/proxy-cache.ts
@@ -13,8 +13,8 @@ export interface ProxyCacheItem {
 
 export interface CacheStats {
   count: number;
-  hitPercentage: number;
-  missPercentage: number;
+  hits: number;
+  misses: number;
 }
 
 export enum CacheEvents {
@@ -62,8 +62,8 @@ export class ProxyCache extends EventEmitter {
   stats(): CacheStats {
     return {
       count: this._cache.stats.keys,
-      hitPercentage: this._cache.stats.hits,
-      missPercentage: this._cache.stats.misses,
+      hits: this._cache.stats.hits,
+      misses: this._cache.stats.misses,
     };
   }
 }

--- a/packages/proxy/src/proxy-metrics.ts
+++ b/packages/proxy/src/proxy-metrics.ts
@@ -1,0 +1,86 @@
+import {Http2ServerRequest} from 'http2';
+import {IncomingMessage} from 'http';
+import url from 'url';
+import {ProxyCache} from './proxy-cache';
+import {CommonEvents, getProxyEventObservable} from './proxy-observable';
+
+let instance: ProxyMetricsObserver | undefined = undefined;
+
+interface MissCount {
+  url: string;
+  misses: number;
+}
+
+interface ProxyMetricData {
+  totalRequests: number;
+  keys: number;
+  hits: number;
+  misses: number;
+  topMissCounts: MissCount[];
+}
+
+/**
+ * The first major use case of such a pipeline is tracking overall stats on how the Proxy is doing
+ */
+class ProxyMetricsObserver {
+  private data: ProxyMetricData = {
+    totalRequests: 0,
+    keys: 0,
+    hits: 0,
+    misses: 0,
+    topMissCounts: [],
+  };
+
+  private trackedMissedUrls: {[url: string]: number} = {};
+
+  private observable = getProxyEventObservable();
+
+  constructor() {
+    // on, on ,on
+    this.observable.on(CommonEvents.requestReceived, () => {
+      this.data.totalRequests++;
+    });
+
+    this.observable.on(
+      CommonEvents.requestUrlNotInCache,
+      (request: IncomingMessage | Http2ServerRequest) => {
+        const parsedUrl = url.parse(request.url!!, true);
+        const path = parsedUrl.pathname!!;
+        // const url = request.url!!;
+        if (parsedUrl === undefined) {
+          console.warn(
+            'Received an event for a requested url, but not url found in the request'
+          );
+          return;
+        }
+        if (this.trackedMissedUrls[path] === undefined) {
+          this.trackedMissedUrls[path] = 0;
+        }
+        this.trackedMissedUrls[path]++;
+      }
+    );
+
+    console.log('Metrics Observer initialized');
+  }
+
+  report(cache: ProxyCache, topN: number = 10): ProxyMetricData {
+    // reuse the data tracked by the proxy cache
+    this.data.keys = cache.stats().count;
+    this.data.hits = cache.stats().hits;
+    this.data.misses = cache.stats().misses;
+    this.data.topMissCounts = Object.entries(this.trackedMissedUrls)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, topN)
+      .map((d) => {
+        return {url: d[0], misses: d[1]};
+      });
+    return this.data;
+  }
+}
+
+export const getProxyMetrics = (): ProxyMetricsObserver => {
+  if (instance === undefined) {
+    instance = new ProxyMetricsObserver();
+  }
+  return instance;
+};

--- a/packages/proxy/src/proxy-observable.ts
+++ b/packages/proxy/src/proxy-observable.ts
@@ -1,0 +1,29 @@
+import EventEmitter from 'events';
+
+let instance: ProxyEventObservable | undefined = undefined;
+
+/**
+ * Given that the Proxy is really multiple simultaneous web servers, it is useful to have a common
+ * 'Pipeline' that events can be emitted 'out' of.
+ */
+class ProxyEventObservable extends EventEmitter {
+  constructor() {
+    super();
+    console.log('Proxy event stream initialized');
+  }
+}
+
+/**
+ * a map of the events we expect to be used throughout the system
+ */
+export const CommonEvents = {
+  requestReceived: 'request-received', // denotes a request to the proxy, this will occur frequently
+  requestUrlNotInCache: 'url-not-cached', // should emit when a url was not found in the cache. Should include the request object in the event
+};
+
+export const getProxyEventObservable = (): ProxyEventObservable => {
+  if (instance === undefined) {
+    instance = new ProxyEventObservable();
+  }
+  return instance;
+};

--- a/packages/proxy/src/reverse-proxy.ts
+++ b/packages/proxy/src/reverse-proxy.ts
@@ -27,7 +27,6 @@ const respondWithMetrics = (
   response: ServerResponse | Http2ServerResponse,
   cache: ProxyCache
 ) => {
-  console.log('Received cache request4');
   // support a query param to expand the top 'n' urls that have been missed
   const topN = parseIntQueryParam(url.parse(request.url!!, true), 'n');
   response.writeHead(200);
@@ -55,7 +54,7 @@ export const handleIncomingRequest = async ({
   getProxyEventObservable().emit(CommonEvents.requestReceived);
   // Check if the resource is in the cache
   const cachedResponse = cache.read(cacheKey);
-  // in order to register a cache miss, we need to actually grab it
+  // in order to register a cache miss, we should attempt to actually grab it
   if (cachedResponse) {
     console.log(`🔑 Key found - ${trimKey(cacheKey)}`);
     response.writeHead(cachedResponse.status, cachedResponse.headers);

--- a/packages/proxy/src/reverse-proxy.ts
+++ b/packages/proxy/src/reverse-proxy.ts
@@ -47,11 +47,7 @@ export const handleIncomingRequest = async ({
   handleUncached: Function;
 }) => {
   if (request.url?.startsWith(CACHE_INFO_URL)) {
-    console.log('Received cache request4');
-    response.writeHead(200);
-    // the stats of the cache itself were note sufficient
-    response.end(JSON.stringify(getProxyMetrics().report(cache)));
-    return;
+    return respondWithMetrics(request, response, cache);
   }
   const requestData = await extractBody(request);
   const cacheKey = calculateCacheKey(request, requestData);


### PR DESCRIPTION
## Description

This PR adds a few things to the Proxy:

* a centralized Observer, allowing a common place for the proxies to publish events and allow other Observers to act on them
* Created the first such Observer, a singleton Proxy Metrics store which tracks the total requests made, and any cache misses
* a special HTTP 1 endpoint which allows for retrieval of these metrics.


The data can be fetched via: `https://<proxy-ip>/rp-cache-info`. (This is naively assuming there's no other path in the world that starts with "rp-cache-info") It also supports a optional query parameter, `n`, mentioned below.

The output of the endpoint shows the totalRequests, hits, misses, and cache key size of the life span of the Proxy. It also includes a field 'topMissCounts' (the size of which is controlled by `n`, e.g. ?n=15), which lists the paths that had a cache miss and the number of occurrences of those misses.
